### PR TITLE
Fixed Biome Hex Colours & Spawns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# =========================
+# Operating System Files
+# =========================
+
+# OSX
+# =========================
+
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+Mods/ValmodIcons/ItemIcons/chemicalAgent - Rumor Says This Can Break EAC.png
+Mods/ValmodIcons/ItemIcons/Class - Veteran - Rumor Says This Can Break EAC.png

--- a/Biome Bundle/WorldBiomes/BirchForestTropicalIsle.bc
+++ b/Biome Bundle/WorldBiomes/BirchForestTropicalIsle.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 11
 
 BiomeRarity: 100
 
-BiomeColor: #ADD917
+BiomeColor: #A5B278
 
 ReplaceToBiomeName: Birch Forest
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Birch Forest
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 11
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 100
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 11
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRAVEL
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (GRAVEL,SAND,62,64),(DIRT,SANDSTONE,62,64),(DIRT,STONE,65,93),(GRAVEL,GRASS,65,122),(STONE,HARD_CLAY,123,211),(GRAVEL,HARD_CLAY,123,211),(DIRT,HARD_CLAY,123,211),(AIR,LAVA,1,10)
 
@@ -212,7 +212,7 @@ Grass(DoubleTallgrass,NotGrouped,4,100.0,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -252,7 +252,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Birch Forest
-

--- a/Biome Bundle/WorldBiomes/Caverns Edge.bc
+++ b/Biome Bundle/WorldBiomes/Caverns Edge.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 90
 
-BiomeColor: #72789A
+BiomeColor: #616995
 
 ReplaceToBiomeName: Roofed Forest
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Roofed Forest
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -209,7 +209,7 @@ Vines(100,10.0,61,161)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -249,7 +249,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Roofed Forest
-

--- a/Biome Bundle/WorldBiomes/CliffsSmallPlateau.bc
+++ b/Biome Bundle/WorldBiomes/CliffsSmallPlateau.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 8
 
 BiomeRarity: 98
 
-BiomeColor: #C2FFAE
+BiomeColor: #A6FA8B
 
 ReplaceToBiomeName: Jungle
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 98
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 8
 
@@ -111,7 +111,7 @@ SurfaceBlock: STAINED_CLAY:1
 
 GroundBlock: STONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (STONE,STAINED_CLAY:1,63,211),(AIR,LAVA,1,10)
 
@@ -201,7 +201,7 @@ Plant(PUMPKIN,1,3.0,0,139,GRASS)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -241,7 +241,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Jungle
-

--- a/Biome Bundle/WorldBiomes/CliffsSmallPlateau2.bc
+++ b/Biome Bundle/WorldBiomes/CliffsSmallPlateau2.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 9
 
 BiomeRarity: 99
 
-BiomeColor: #C2FFAE
+BiomeColor: #ADF097
 
 ReplaceToBiomeName: Jungle
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 99
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 8
 
@@ -111,7 +111,7 @@ SurfaceBlock: STAINED_CLAY:1
 
 GroundBlock: STONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (STONE,STAINED_CLAY:1,63,211),(AIR,LAVA,1,10)
 
@@ -199,7 +199,7 @@ Plant(PUMPKIN,1,3.0,0,139,GRASS)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -239,7 +239,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Jungle
-

--- a/Biome Bundle/WorldBiomes/Desert M.bc
+++ b/Biome Bundle/WorldBiomes/Desert M.bc
@@ -238,9 +238,9 @@ RareBuildingType: disabled
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}]
+SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Desert M.bc
+++ b/Biome Bundle/WorldBiomes/Desert M.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #C08F06
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -109,7 +109,7 @@ SurfaceBlock: SAND
 
 GroundBlock: SANDSTONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ Well(SANDSTONE,STEP:1,WATER,1,0.1,13,139,SAND)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -238,7 +238,7 @@ RareBuildingType: disabled
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}]
 
@@ -249,4 +249,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, DRY, SANDY
 
 InheritMobsBiomeName: Desert M
-

--- a/Biome Bundle/WorldBiomes/Desert.bc
+++ b/Biome Bundle/WorldBiomes/Desert.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #E48717
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 5
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 5
 
@@ -109,7 +109,7 @@ SurfaceBlock: SAND
 
 GroundBlock: SANDSTONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -197,7 +197,7 @@ Well(SANDSTONE,STEP:1,WATER,1,0.1,13,139,SAND)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -229,7 +229,7 @@ RareBuildingType: disabled
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}]
 
@@ -240,4 +240,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, DRY, SANDY
 
 InheritMobsBiomeName: Desert
-

--- a/Biome Bundle/WorldBiomes/Desert.bc
+++ b/Biome Bundle/WorldBiomes/Desert.bc
@@ -229,9 +229,9 @@ RareBuildingType: disabled
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}]
+SpawnCreatures: [{"mob": "rabbit", "weight": 4, "min": 2, "max": 3}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/DesertCanyon.bc
+++ b/Biome Bundle/WorldBiomes/DesertCanyon.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 100
 
-BiomeColor: #056621
+BiomeColor: #646605
 
 ReplaceToBiomeName: Savanna
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Savanna
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: SAND:1
 
 GroundBlock: RED_SANDSTONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (STONE,RED_SANDSTONE,63,250),(SAND,STAINED_CLAY:4,81,84),(RED_SANDSTONE,STAINED_CLAY:4,81,84),(SAND,STAINED_CLAY:4,92,93),(RED_SANDSTONE,STAINED_CLAY:4,92,93),(AIR,LAVA,1,10)
 
@@ -220,7 +220,7 @@ CustomObject(SandSmallLake1,SandSmallLake2,SandSmallLake3,SandSmallLake4,SandSma
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -260,7 +260,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Savanna
-

--- a/Biome Bundle/WorldBiomes/DrylandsEdge1.bc
+++ b/Biome Bundle/WorldBiomes/DrylandsEdge1.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 11
 
 BiomeRarity: 100
 
-BiomeColor: #000000
+BiomeColor: #36372D
 
 ReplaceToBiomeName: Tundra
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Tundra
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 11
 
@@ -40,7 +40,7 @@ BiomeRarityWhenIsle: 100
 
 BiomeIsBorder: DrylandsIsle, ForestLarch
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 11
 
@@ -111,7 +111,7 @@ SurfaceBlock: STONE
 
 GroundBlock: STONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (STONE,STAINED_CLAY:9,72,73),(STONE,STAINED_CLAY:9,76,76),(STONE,STAINED_CLAY:9,80,80),(STONE,STAINED_CLAY:9,82,82),(STONE,STAINED_CLAY:9,88,89),(STONE,STAINED_CLAY:9,96,96),(STONE,STAINED_CLAY:9,98,98),(STONE,STAINED_CLAY:9,104,105),(STONE,STAINED_CLAY:9,109,109),(STONE,STAINED_CLAY:9,113,114),(STONE,STAINED_CLAY:9,121,121),(AIR,LAVA,1,10)
 
@@ -196,7 +196,7 @@ SmallLake(LAVA,6,33.0,1,8)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -236,7 +236,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Tundra
-

--- a/Biome Bundle/WorldBiomes/Extreme Hills M.bc
+++ b/Biome Bundle/WorldBiomes/Extreme Hills M.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 95
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 8
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: GRASS, DIRT, 1.0, STONE, STONE, 10.0 
+SurfaceAndGroundControl: GRASS, DIRT, 1.0, STONE, STONE, 10.0
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ CustomStructure(Bricktowerbranching,0.1,GravelOreT1,1.0,CaveMine1,0.09,RedbrickH
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -249,4 +249,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: MOUNTAIN, HILLS
 
 InheritMobsBiomeName: Extreme Hills M
-

--- a/Biome Bundle/WorldBiomes/Extreme Hills+ M.bc
+++ b/Biome Bundle/WorldBiomes/Extreme Hills+ M.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #466246
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 4
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 10
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 4
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: GRAVEL, GRAVEL, -1.0, GRASS, DIRT, 2.0, GRAVEL, GRAVEL, 10.0 
+SurfaceAndGroundControl: GRAVEL, GRAVEL, -1.0, GRASS, DIRT, 2.0, GRAVEL, GRAVEL, 10.0
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -203,7 +203,7 @@ Liquid(LAVA,10,100.0,19,139,STONE:0)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -237,7 +237,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -246,4 +246,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: MOUNTAIN, FOREST, SPARSE
 
 InheritMobsBiomeName: Extreme Hills+ M
-

--- a/Biome Bundle/WorldBiomes/Extreme Hills+.bc
+++ b/Biome Bundle/WorldBiomes/Extreme Hills+.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 95
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 9
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: GRASS, DIRT, 0.0, STONE, STONE, 10.0 
+SurfaceAndGroundControl: GRASS, DIRT, 0.0, STONE, STONE, 10.0
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ CustomStructure(Bricktowerbranching,0.1,GravelOreT1,1.0,BrickRuinsPath1,0.1,Cave
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -249,4 +249,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: MOUNTAIN, FOREST, SPARSE
 
 InheritMobsBiomeName: Extreme Hills+
-

--- a/Biome Bundle/WorldBiomes/Extreme Hills.bc
+++ b/Biome Bundle/WorldBiomes/Extreme Hills.bc
@@ -238,7 +238,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Extreme Hills.bc
+++ b/Biome Bundle/WorldBiomes/Extreme Hills.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #50AD3F
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: GRASS, DIRT, 1.0, STONE, STONE, 10.0 
+SurfaceAndGroundControl: GRASS, DIRT, 1.0, STONE, STONE, 10.0
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -204,7 +204,7 @@ CustomStructure(TotemBase,0.1,Bricktowerbranching,0.1,GravelOreT1,1.0,BrickRuins
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -238,7 +238,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -247,4 +247,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: MOUNTAIN, HILLS
 
 InheritMobsBiomeName: Extreme Hills
-

--- a/Biome Bundle/WorldBiomes/ForestConiferEdge.bc
+++ b/Biome Bundle/WorldBiomes/ForestConiferEdge.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 95
 
-BiomeColor: #056621
+BiomeColor: #157B33
 
 ReplaceToBiomeName: ForestConifer
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: ForestConifer
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -209,7 +209,7 @@ Grass(Tallgrass,NotGrouped,10,100.0,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -249,7 +249,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Forest
-

--- a/Biome Bundle/WorldBiomes/ForestConiferSnow.bc
+++ b/Biome Bundle/WorldBiomes/ForestConiferSnow.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 9
 
 BiomeRarity: 98
 
-BiomeColor: #056621
+BiomeColor: #75D77B
 
 ReplaceToBiomeName: ForestConifer
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 98
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 9
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -207,7 +207,7 @@ Plant(LargeFern,15,100.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -247,7 +247,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Forest
-

--- a/Biome Bundle/WorldBiomes/ForestEnderMountain.bc
+++ b/Biome Bundle/WorldBiomes/ForestEnderMountain.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 99
 
-BiomeColor: #9EC4DE
+BiomeColor: #3C1157
 
 ReplaceToBiomeName: ForestEnder
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 99
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -213,7 +213,7 @@ Plant(LargeFern,4,20.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -253,7 +253,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: ForestEnder
-

--- a/Biome Bundle/WorldBiomes/ForestFirMountainEdge2.bc
+++ b/Biome Bundle/WorldBiomes/ForestFirMountainEdge2.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 11
 
 BiomeRarity: 100
 
-BiomeColor: #000000
+BiomeColor: #278823
 
 ReplaceToBiomeName: Extreme Hills
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Extreme Hills
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 11
 
@@ -40,7 +40,7 @@ BiomeRarityWhenIsle: 100
 
 BiomeIsBorder: ForestFirMountain
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 11
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (DIRT,STONE,126,211),(GRASS,STONE,126,211),(AIR,LAVA,1,10)
 
@@ -217,7 +217,7 @@ Plant(SNOW,80,45.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -257,7 +257,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Extreme Hills
-

--- a/Biome Bundle/WorldBiomes/ForestSakuraHills.bc
+++ b/Biome Bundle/WorldBiomes/ForestSakuraHills.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,9 +20,9 @@ BiomeSize: 11
 
 BiomeRarity: 99
 
-BiomeColor: #C2FFAE
+BiomeColor: #A67EB2
 
-ReplaceToBiomeName: 
+ReplaceToBiomeName:
 
 ####################
 # Isle biomes only #
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 99
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (WATER,STONE,32,51),(AIR,LAVA,1,10)
 
@@ -223,7 +223,7 @@ CustomObject(UndergroundDungeon1,UndergroundDungeon2,UndergroundDungeon3,Undergr
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -266,4 +266,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: FOREST
 
 InheritMobsBiomeName: Forest
-

--- a/Biome Bundle/WorldBiomes/HighCliffsThicket.bc
+++ b/Biome Bundle/WorldBiomes/HighCliffsThicket.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 8
 
 BiomeRarity: 99
 
-BiomeColor: #056621
+BiomeColor: #4F6234
 
 ReplaceToBiomeName: Forest
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 99
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 8
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: STAINED_CLAY:9, STAINED_CLAY:9, -0.8 
+SurfaceAndGroundControl: STAINED_CLAY:9, STAINED_CLAY:9, -0.8
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -209,7 +209,7 @@ Plant(LargeFern,15,100.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -249,7 +249,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Forest
-

--- a/Biome Bundle/WorldBiomes/Jungle M.bc
+++ b/Biome Bundle/WorldBiomes/Jungle M.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 80
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 9
 
@@ -109,7 +109,7 @@ SurfaceBlock: STONE
 
 GroundBlock: STONE
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (STONE,HARD_CLAY,63,83),(AIR,LAVA,1,10)
 
@@ -205,7 +205,7 @@ Grass(Tallgrass,NotGrouped,10,100.0,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -237,9 +237,9 @@ RareBuildingType: disabled
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 1}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 2}, {"mob": "parrot", "weight": 4, "min": 2, "max": 3}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -248,4 +248,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, WET, DENSE, JUNGLE
 
 InheritMobsBiomeName: Jungle M
-

--- a/Biome Bundle/WorldBiomes/Jungle.bc
+++ b/Biome Bundle/WorldBiomes/Jungle.bc
@@ -248,9 +248,9 @@ RareBuildingType: jungleTemple
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 1}]
+SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "ocelot", "weight": 5, "min": 4, "max": 4}, {"mob": "parrot", "weight": 6, "min": 1, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 2}, {"mob": "parrot", "weight": 4, "min": 2, "max": 3}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Jungle.bc
+++ b/Biome Bundle/WorldBiomes/Jungle.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #3EF51C
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 5
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 5
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: HARD_CLAY
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -216,7 +216,7 @@ Reed(SUGAR_CANE_BLOCK,10,100.0,63,139,GRASS,DIRT,SAND)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -250,7 +250,7 @@ RareBuildingType: jungleTemple
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "ocelot", "weight": 5, "min": 4, "max": 4}, {"mob": "parrot", "weight": 6, "min": 1, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -259,4 +259,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, WET, DENSE, JUNGLE
 
 InheritMobsBiomeName: Jungle
-

--- a/Biome Bundle/WorldBiomes/JungleHills.bc
+++ b/Biome Bundle/WorldBiomes/JungleHills.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #8ABD7C
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 5
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 5
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -208,7 +208,7 @@ Reed(SUGAR_CANE_BLOCK,10,100.0,63,139,GRASS,DIRT,SAND)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -242,7 +242,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}, {"mob": "ocelot", "weight": 2, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "parrot", "weight": 4, "min": 2, "max": 3}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -251,4 +251,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, WET, DENSE, JUNGLE, HILLS
 
 InheritMobsBiomeName: JungleHills
-

--- a/Biome Bundle/WorldBiomes/Mesa River.bc
+++ b/Biome Bundle/WorldBiomes/Mesa River.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 99
 
-BiomeColor: #D94515
+BiomeColor: #C99C74
 
 ReplaceToBiomeName: Forest
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Forest
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 10
 
@@ -84,7 +84,7 @@ CustomHeightControl: 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 # ImprovedRivers:false #
 ########################
 
-RiverBiome: 
+RiverBiome:
 
 #######################
 # ImprovedRivers:true #
@@ -201,7 +201,7 @@ UnderWaterOre(GRAVEL,8,2,100.0,SAND,HARD_CLAY)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -241,7 +241,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: River
-

--- a/Biome Bundle/WorldBiomes/Mesa Verde.bc
+++ b/Biome Bundle/WorldBiomes/Mesa Verde.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 5
 
 BiomeRarity: 99
 
-BiomeColor: #537B09
+BiomeColor: #C1DD4C
 
 ReplaceToBiomeName: Jungle
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Jungle
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 5
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 5
 
@@ -217,7 +217,7 @@ Plant(LargeFern,10,100.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -257,7 +257,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Forest
-

--- a/Biome Bundle/WorldBiomes/MonumentMountainsPeak1.bc
+++ b/Biome Bundle/WorldBiomes/MonumentMountainsPeak1.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 9
 
 BiomeRarity: 98
 
-BiomeColor: #C2FFAE
+BiomeColor: #6D9CAC
 
 ReplaceToBiomeName: Uplands
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 98
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 9
 
@@ -204,7 +204,7 @@ Plant(SNOW,80,90.0,146,255,GRASS,DIRT,STONE:0,LEAVES)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -244,7 +244,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Extreme Hills
-

--- a/Biome Bundle/WorldBiomes/Plains.bc
+++ b/Biome Bundle/WorldBiomes/Plains.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #C8C563
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 7
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 60
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 7
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -204,7 +204,7 @@ Ore(STONE,5,25,100.0,71,76,GRASS)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -238,7 +238,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 4, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -247,4 +247,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: PLAINS
 
 InheritMobsBiomeName: Plains
-

--- a/Biome Bundle/WorldBiomes/Plains.bc
+++ b/Biome Bundle/WorldBiomes/Plains.bc
@@ -238,7 +238,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/RainforestTropical.bc
+++ b/Biome Bundle/WorldBiomes/RainforestTropical.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 6
 
 BiomeRarity: 70
 
-BiomeColor: #4D552B
+BiomeColor: #7FAA20
 
 ReplaceToBiomeName: Jungle
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Jungle
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRAVEL
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: STAINED_CLAY:14, DIRT, -4.0, GRASS, STONE, 0.0, STAINED_CLAY:14, DIRT, 0.5, HARD_CLAY, DIRT, 1.0, STAINED_CLAY:14, DIRT, 1.5, GRASS, DIRT, 10.0 
+SurfaceAndGroundControl: STAINED_CLAY:14, DIRT, -4.0, GRASS, STONE, 0.0, STAINED_CLAY:14, DIRT, 0.5, HARD_CLAY, DIRT, 1.0, STAINED_CLAY:14, DIRT, 1.5, GRASS, DIRT, 10.0
 
 ReplacedBlocks: (GRASS,SAND:1,62,63),(STONE,HARD_CLAY,62,255),(AIR,LAVA,1,10)
 
@@ -216,7 +216,7 @@ Plant(MELON_BLOCK,1,100.0,0,139,GRASS,DIRT,DIRT:2)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -256,7 +256,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Jungle
-

--- a/Biome Bundle/WorldBiomes/Redwood Forest.bc
+++ b/Biome Bundle/WorldBiomes/Redwood Forest.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 6
 
 BiomeRarity: 70
 
-BiomeColor: #FA9418
+BiomeColor: #730808
 
 ReplaceToBiomeName: Taiga
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Taiga
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -213,7 +213,7 @@ Plant(LargeFern,10,90.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -253,7 +253,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Taiga
-

--- a/Biome Bundle/WorldBiomes/RiverEnder.bc
+++ b/Biome Bundle/WorldBiomes/RiverEnder.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 4
 
 BiomeRarity: 80
 
-BiomeColor: #056621
+BiomeColor: #031B9A
 
 ReplaceToBiomeName: ForestEnder
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: ForestEnder
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 4
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 80
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 4
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (GRASS,SAND,62,62),(AIR,LAVA,1,10)
 
@@ -207,7 +207,7 @@ Plant(LargeFern,10,100.0,41,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -247,7 +247,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: ForestEnder
-

--- a/Biome Bundle/WorldBiomes/Savanna M.bc
+++ b/Biome Bundle/WorldBiomes/Savanna M.bc
@@ -233,7 +233,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Savanna M.bc
+++ b/Biome Bundle/WorldBiomes/Savanna M.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 9
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: STONE
 
-SurfaceAndGroundControl: GRASS, DIRT, -0.5, DIRT:1, DIRT, 1.75, STONE, STONE, 10.0 
+SurfaceAndGroundControl: GRASS, DIRT, -0.5, DIRT:1, DIRT, 1.75, STONE, STONE, 10.0
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -199,7 +199,7 @@ Plant(Dandelion,4,100.0,0,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -233,7 +233,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -242,4 +242,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, SAVANNA, PLAINS, SPARSE
 
 InheritMobsBiomeName: Savanna M
-

--- a/Biome Bundle/WorldBiomes/Savanna.bc
+++ b/Biome Bundle/WorldBiomes/Savanna.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #BDB25F
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ Plant(Dandelion,4,100.0,0,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -249,4 +249,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: HOT, SAVANNA, PLAINS, SPARSE
 
 InheritMobsBiomeName: Savanna
-

--- a/Biome Bundle/WorldBiomes/Savanna.bc
+++ b/Biome Bundle/WorldBiomes/Savanna.bc
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 1, "min": 2, "max": 6}, {"mob": "llama", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Sky.bc
+++ b/Biome Bundle/WorldBiomes/Sky.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends:
+BiomeExtends: 
 
 ResourceInheritance: true
 
@@ -16,7 +16,7 @@ ResourceInheritance: true
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeSize: 6
+BiomeSize: 4
 
 BiomeRarity: 100
 
@@ -26,7 +26,7 @@ BiomeColor: #8080FF
 # Isle biomes only #
 ####################
 
-IsleInBiome:
+IsleInBiome: 
 
 BiomeSizeWhenIsle: 4
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 100
 # Border biomes only #
 ######################
 
-BiomeIsBorder:
+BiomeIsBorder: 
 
-NotBorderNear:
+NotBorderNear: 
 
 BiomeSizeWhenBorder: 4
 
@@ -82,7 +82,7 @@ CustomHeightControl: 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 # ImprovedRivers:false #
 ########################
 
-RiverBiome:
+RiverBiome: 
 
 #######################
 # ImprovedRivers:true #
@@ -109,7 +109,7 @@ SurfaceBlock: DIRT
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl:
+SurfaceAndGroundControl: 
 
 ReplacedBlocks: None
 
@@ -185,7 +185,7 @@ Liquid(LAVA,10,100.0,19,139,STONE:0)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects:
+BiomeObjects: 
 
 
 #######################################################################
@@ -228,3 +228,4 @@ SpawnAmbientCreatures: []
 BiomeDictId: COLD, DRY, END
 
 InheritMobsBiomeName: Sky
+

--- a/Biome Bundle/WorldBiomes/Sky.bc
+++ b/Biome Bundle/WorldBiomes/Sky.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -16,7 +16,7 @@ ResourceInheritance: true
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeSize: 4
+BiomeSize: 6
 
 BiomeRarity: 100
 
@@ -26,7 +26,7 @@ BiomeColor: #8080FF
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 4
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 100
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 4
 
@@ -82,7 +82,7 @@ CustomHeightControl: 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
 # ImprovedRivers:false #
 ########################
 
-RiverBiome: 
+RiverBiome:
 
 #######################
 # ImprovedRivers:true #
@@ -109,7 +109,7 @@ SurfaceBlock: DIRT
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: None
 
@@ -185,7 +185,7 @@ Liquid(LAVA,10,100.0,19,139,STONE:0)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -228,4 +228,3 @@ SpawnAmbientCreatures: []
 BiomeDictId: COLD, DRY, END
 
 InheritMobsBiomeName: Sky
-

--- a/Biome Bundle/WorldBiomes/Steppe.bc
+++ b/Biome Bundle/WorldBiomes/Steppe.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,15 +20,15 @@ BiomeSize: 6
 
 BiomeRarity: 70
 
-BiomeColor: #ADD917
+BiomeColor: #99BD1D
 
-ReplaceToBiomeName: 
+ReplaceToBiomeName:
 
 ####################
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 6
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 70
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 6
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -210,7 +210,7 @@ Plant(BrownMushroom,1,10.0,0,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -253,4 +253,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: PLAINS, SPARSE
 
 InheritMobsBiomeName: Plains
-

--- a/Biome Bundle/WorldBiomes/SteppeHill.bc
+++ b/Biome Bundle/WorldBiomes/SteppeHill.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 10
 
 BiomeRarity: 97
 
-BiomeColor: #ADD917
+BiomeColor: #A4B567
 
 ReplaceToBiomeName: Steppe
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 10
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -212,7 +212,7 @@ Plant(BrownMushroom,1,10.0,0,139,GRASS,DIRT)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -252,7 +252,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Steppe
-

--- a/Biome Bundle/WorldBiomes/Sunflower Plains.bc
+++ b/Biome Bundle/WorldBiomes/Sunflower Plains.bc
@@ -206,7 +206,7 @@ CustomStructure(Bricktowerbranching,0.1,GravelOreT1,1.0,BrickRuinsPath1,0.1,Cave
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects:
+BiomeObjects: 
 
 
 #######################################################################
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 4, "max": 4}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 2, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 

--- a/Biome Bundle/WorldBiomes/Sunflower Plains.bc
+++ b/Biome Bundle/WorldBiomes/Sunflower Plains.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -26,7 +26,7 @@ BiomeColor: #DEFF00
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 7
 
@@ -36,9 +36,9 @@ BiomeRarityWhenIsle: 60
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 7
 
@@ -109,7 +109,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ CustomStructure(Bricktowerbranching,0.1,GravelOreT1,1.0,BrickRuinsPath1,0.1,Cave
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -240,7 +240,7 @@ RareBuildingType: disabled
 
 SpawnMonsters: [{"mob": "spider", "weight": 100, "min": 4, "max": 4}, {"mob": "zombie", "weight": 100, "min": 4, "max": 4}, {"mob": "skeleton", "weight": 100, "min": 4, "max": 4}, {"mob": "creeper", "weight": 100, "min": 4, "max": 4}, {"mob": "slime", "weight": 100, "min": 4, "max": 4}, {"mob": "enderman", "weight": 10, "min": 1, "max": 4}, {"mob": "witch", "weight": 5, "min": 1, "max": 1}]
 
-SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}]
+SpawnCreatures: [{"mob": "sheep", "weight": 12, "min": 4, "max": 4}, {"mob": "pig", "weight": 10, "min": 4, "max": 4}, {"mob": "chicken", "weight": 10, "min": 4, "max": 4}, {"mob": "cow", "weight": 8, "min": 4, "max": 4}, {"mob": "horse", "weight": 5, "min": 2, "max": 6}, {"mob": "mule", "weight": 5, "min": 4, "max": 4}]
 
 SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
@@ -249,4 +249,3 @@ SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 BiomeDictId: PLAINS
 
 InheritMobsBiomeName: Sunflower Plains
-

--- a/Biome Bundle/WorldBiomes/TemperatePlains.bc
+++ b/Biome Bundle/WorldBiomes/TemperatePlains.bc
@@ -5,7 +5,7 @@
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeExtends: 
+BiomeExtends:
 
 ResourceInheritance: true
 
@@ -20,7 +20,7 @@ BiomeSize: 5
 
 BiomeRarity: 99
 
-BiomeColor: #C2FFAE
+BiomeColor: #BCE070
 
 ReplaceToBiomeName: Plains
 
@@ -28,7 +28,7 @@ ReplaceToBiomeName: Plains
 # Isle biomes only #
 ####################
 
-IsleInBiome: 
+IsleInBiome:
 
 BiomeSizeWhenIsle: 5
 
@@ -38,9 +38,9 @@ BiomeRarityWhenIsle: 97
 # Border biomes only #
 ######################
 
-BiomeIsBorder: 
+BiomeIsBorder:
 
-NotBorderNear: 
+NotBorderNear:
 
 BiomeSizeWhenBorder: 5
 
@@ -111,7 +111,7 @@ SurfaceBlock: GRASS
 
 GroundBlock: DIRT
 
-SurfaceAndGroundControl: 
+SurfaceAndGroundControl:
 
 ReplacedBlocks: (AIR,LAVA,1,10)
 
@@ -206,7 +206,7 @@ Reed(SUGAR_CANE_BLOCK,3,100.0,0,139,GRASS,DIRT,SAND)
 # +-----------------------------------------------------------------+ #
 #######################################################################
 
-BiomeObjects: 
+BiomeObjects:
 
 
 #######################################################################
@@ -246,7 +246,6 @@ SpawnWaterCreatures: [{"mob": "squid", "weight": 10, "min": 4, "max": 4}]
 
 SpawnAmbientCreatures: [{"mob": "bat", "weight": 10, "min": 8, "max": 8}]
 
-BiomeDictId: 
+BiomeDictId:
 
 InheritMobsBiomeName: Plains
-

--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
-Biome Bundle v6 Changelog
+### Biome Bundle +: Version 1.0
 
-    Raised sea level to Y63 to improve mod compatibility and create more space underground (integrated all of SamGungraven's changes)
-    Ore generation is now vanilla, with the exception of emeralds which have a small chance to appear in any biome
-    Made volatility values more similar between biomes to improve terrain smoothing between biomes
-    Changed global 'fracture' settings to prevent overhanging terrain and create more realistic landscapes
-    Tweaked ocean and continent sizes so huge oceans are created less often
-    Overhauled ice biome group
-    Re-enabled vanilla ocean monuments
-    Fixed cut-off structures (Issue 77) https://github.com/BiomeBundle/BiomeBundle/issues/77
-    Fixed double entries: https://github.com/BiomeBundle/BiomeBundle/issues/83
-    Re-enabled biomes https://github.com/BiomeBundle/BiomeBundle/issues/84
-    Created a few new biomes using new trees, rocks, etc. Also added a few new flatter variants of existing biomes to create easier to traverse variations.
-    Rebalanced the rarity of all structures to make variation more likely and to make rarer structures like the custom mansions slightly more likely to spawn
-    Fix for books not correctly enchanted in loot chests
-    Fixed uppercase/lowercase file name issues that affected linux environments
-    Fixed incorrect data in flower pots generated in structures
-    Reviewed mob spawners, some structures had them too closely together making it to easy to create mob farms
-    Added a couple more structure variants added to existing structure lists
-    Lots of small enhancements to existing biomes
-    Note: This version is not compatible with worlds made with previous versions of Biome Bundle. Biomes have been added/removed and so seeds no longer generate the same layout. Starting a brand new world is recommended.
+#### Change-log
+
+* Added Unique Colour Values to all *.bc config files (Thanks too @whywaitewebs)
+* Fixed Vanilla Mob Spawns for vanilla biomes (Llama,Ocelot,Parrot,Mules)
+
+>This is a Fork of Biome Bundle v6.1


### PR DESCRIPTION
Updated Biome Hex Colours & Fixed Missing Vanilla Mob Spawns in (Desert, DesertM, Savanna, SavannaM, Extreme Hills, Extreme Hills M, Extreme Hills+, Extreme Hills+ M, Jungle, Jungle M, Jungle Hills, Jungle Cliffs, Plains, Sunflower Plains)